### PR TITLE
[feature/lsp] - Add LSP support

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,10 +1,19 @@
 {
+  "cmp-nvim-lsp": { "branch": "main", "commit": "a8912b88ce488f411177fc8aed358b04dc246d7b" },
   "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
+  "mason-lspconfig.nvim": { "branch": "main", "commit": "a9c876d72d82b6640266f8b248ac05a63630b1d9" },
+  "mason.nvim": { "branch": "main", "commit": "8024d64e1330b86044fed4c8494ef3dcd483a67c" },
+  "nvim-cmp": { "branch": "main", "commit": "b5311ab3ed9c846b585c0c15b7559be131ec4be9" },
+  "nvim-lspconfig": { "branch": "master", "commit": "d3934000788ab0a8f98ed58bc69e4b73ad26b110" },
   "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
   "nvim-ts-autotag": { "branch": "main", "commit": "a1d526af391f6aebb25a8795cbc05351ed3620b5" },
   "nvim-web-devicons": { "branch": "master", "commit": "0422a19d9aa3aad2c7e5cca167e5407b13407a9d" },
   "oil.nvim": { "branch": "master", "commit": "bbad9a76b2617ce1221d49619e4e4b659b3c61fc" },
+  "plenary.nvim": { "branch": "master", "commit": "857c5ac632080dba10aae49dba902ce3abf91b35" },
   "smear-cursor.nvim": { "branch": "main", "commit": "69b2d4aa715dc2ead1aa772e19bc241b561a68fa" },
+  "snacks.nvim": { "branch": "main", "commit": "bc0630e43be5699bb94dadc302c0d21615421d93" },
   "solarized-osaka.nvim": { "branch": "main", "commit": "f796014c14b1910e08d42cc2077fef34f08e0295" },
+  "telescope-fzf-native.nvim": { "branch": "main", "commit": "1f08ed60cafc8f6168b72b80be2b2ea149813e55" },
+  "telescope.nvim": { "branch": "master", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
   "which-key.nvim": { "branch": "main", "commit": "370ec46f710e058c9c1646273e6b225acf47cbed" }
 }

--- a/lua/plugins/autocompletion.lua
+++ b/lua/plugins/autocompletion.lua
@@ -1,0 +1,8 @@
+return {
+  {
+    "hrsh7th/nvim-cmp", -- TODO: Improve configuration
+    dependencies = {
+      "hrsh7th/cmp-nvim-lsp",
+    },
+  },
+}

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -1,0 +1,79 @@
+local servers = {
+  "lua_ls",
+  "ts_ls",
+  "ruby_lsp",
+  "pyright",
+  "graphql",
+  "eslint",
+  "jsonls",
+  "html",
+  "cssls",
+  "scss_ls",
+  "tailwindcss",
+  "yamlls",
+}
+
+return {
+  {
+    "williamboman/mason.nvim",
+    build = ":MasonUpdate",
+    config = function()
+      require("mason").setup()
+    end,
+  },
+
+  {
+    "williamboman/mason-lspconfig.nvim",
+    config = function()
+      require("mason-lspconfig").setup({
+        ensure_installed = servers,
+      })
+    end,
+  },
+
+  {
+    "neovim/nvim-lspconfig",
+    config = function()
+      local lspconfig = require("lspconfig")
+      local capabilities = require("cmp_nvim_lsp").default_capabilities()
+
+      for _, server in ipairs(servers) do
+        if server == "lua_ls" then -- Get the lua_ls language server to recognize the vim global
+          lspconfig[server].setup {
+            capabilities = capabilities,
+            settings = {
+              Lua = {
+                diagnostics = {
+                  globals = { "vim", "Snacks" },
+                },
+              },
+            },
+          }
+        else
+          lspconfig[server].setup {
+            capabilities = capabilities,
+          }
+        end
+      end
+
+      vim.keymap.set("n", "K", vim.lsp.buf.hover, {}) -- When hovering over an element I can press shift+k to see its documentation
+      vim.keymap.set("n", "gd", vim.lsp.buf.definition, {}) -- Go to definition
+      --[[
+        Keymap below enables code actions such as auto-import missing modules, rename variable,
+        applying ESLint fixes, adding missing type annotations, etc
+      ]]
+      vim.keymap.set({ "n", "v" }, "<leader>ca", vim.lsp.buf.code_action, {})
+    end,
+  },
+
+  {
+    "folke/snacks.nvim", -- Collection of small QoL plugins
+    priority = 1000,
+    lazy = false,
+    opts = {
+      input = { enabled = true },
+      picker = { enabled = true },
+    },
+  }
+}
+

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -32,6 +32,8 @@ return {
           "node_modules/*",
           "package%-lock.json",
           "lazy%-lock.json",
+          "yarn.lock",
+          "pnpm%-lock.yaml",
           "%[No Name%]",
         },
       },

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -20,7 +20,9 @@ return { -- Generates an AST. This info is then utilized for highlighting, editi
 			"python",
 			"json",
 			"css",
+      "scss",
 			"tsx",
+      "regex",
 		},
 
 		auto_install = true, -- Autoinstall languages that are not installed


### PR DESCRIPTION
- Add `mason.nvim` to handle language servers installation.
- Add `mason-lspconfig.nvim` and `nvim-lspconfig` for lsp configuration and initialization.

Additional Notes:
- Add `nvim-cmp` so that I could use `cmp-nvim-lsp` in my `lsp.lua`.
- Add `picker` and `input` utilities from `snacks` plugin to improve code actions and other lsp-related features. Was going to use `dressing.nvim` but apparently the project has recently been archived. 
- Exclude `yarn.lock` and `pnpm-lock.yaml` from `Telescope` searches for cleaner results.
- Add `scss` and `regex` parsers to Tresitter's `ensure_installed` list.